### PR TITLE
Fix: Resolve Georgie Porgies ecosystem test failure with hybrid extraction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ A web scraping application that collects daily frozen custard flavors from multi
 - **Scraping**: Playwright (dynamic sites and Facebook), BeautifulSoup (static sites), Selenium (legacy only)
 - **Testing**: pytest with unittest
 - **Formatting**: black, flake8, isort, autoflake
-- **Package Management**: pip with pyproject.toml
+- **Package Management**: uv with pyproject.toml
 
 ## Project Structure
 ```
@@ -205,18 +205,16 @@ All scrapers return list of dicts:
 10. **Document complex regex patterns** with examples
 
 ## Python Environment (Required)
-- **Always activate the project virtual environment before running any Python-based shell command**.
-- Activation command: `source .venv/bin/activate`
-- This applies to `python`, `pytest`, `black`, `flake8`, `isort`, `pip`, and any script that relies on Python packages.
-- When running one-off commands, prefer chaining activation in the same command, for example:
-    `source .venv/bin/activate && pytest tests/ -v`
+- **Always use `uv run` to invoke Python-based shell commands** — do not activate the virtual environment manually.
+- This applies to `python`, `pytest`, `black`, `flake8`, `isort`, and any script that relies on Python packages.
+- Install/sync dependencies with `uv sync --all-extras --frozen` before running commands for the first time.
 
 ## Commands
-- Run tests: `source .venv/bin/activate && pytest tests/ -v`
-- Run ecosystem tests: `source .venv/bin/activate && pytest --ecosystem`
-- Format code: `source .venv/bin/activate && black app/ tests/`
-- Lint: `source .venv/bin/activate && flake8 app/ tests/`
-- Sort imports: `source .venv/bin/activate && isort app/ tests/`
+- Run tests: `uv run pytest tests/ -v`
+- Run ecosystem tests: `uv run pytest --ecosystem`
+- Format code: `uv run black app/ tests/`
+- Lint: `uv run flake8 app/ tests/`
+- Sort imports: `uv run isort app/ tests/`
 
 ## When Adding New Scrapers
 1. Create scraper class inheriting from `BaseScraper`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,12 +204,19 @@ All scrapers return list of dicts:
 9. **Use constants** for magic numbers (timeouts, retries, etc.)
 10. **Document complex regex patterns** with examples
 
+## Python Environment (Required)
+- **Always activate the project virtual environment before running any Python-based shell command**.
+- Activation command: `source .venv/bin/activate`
+- This applies to `python`, `pytest`, `black`, `flake8`, `isort`, `pip`, and any script that relies on Python packages.
+- When running one-off commands, prefer chaining activation in the same command, for example:
+    `source .venv/bin/activate && pytest tests/ -v`
+
 ## Commands
-- Run tests: `pytest tests/ -v`
-- Run ecosystem tests: `pytest --ecosystem`
-- Format code: `black app/ tests/`
-- Lint: `flake8 app/ tests/`
-- Sort imports: `isort app/ tests/`
+- Run tests: `source .venv/bin/activate && pytest tests/ -v`
+- Run ecosystem tests: `source .venv/bin/activate && pytest --ecosystem`
+- Format code: `source .venv/bin/activate && black app/ tests/`
+- Lint: `source .venv/bin/activate && flake8 app/ tests/`
+- Sort imports: `source .venv/bin/activate && isort app/ tests/`
 
 ## When Adding New Scrapers
 1. Create scraper class inheriting from `BaseScraper`

--- a/app/scrapers/georgieporgies.py
+++ b/app/scrapers/georgieporgies.py
@@ -5,6 +5,7 @@ import re
 from bs4 import BeautifulSoup
 
 from app.scrapers.scraper_base import USER_AGENT, BaseScraper
+from app.scrapers.utils import get_central_date_string
 
 GEORGIE_PORGIES_FORECAST_URL = "https://georgieporgies.com/georgies-flavor-forecast/"
 PAGE_TIMEOUT = 30000  # 30s
@@ -36,13 +37,21 @@ class GeorgiePorgiesScraper(BaseScraper):
                     self.log_error("Failed to get HTML")
                     return []
 
-            flavor_name, description = self._extract_todays_flavor(html)
+            flavor_name, description, extraction_path = self._extract_todays_flavor(html)
+            if extraction_path:
+                self.logger.info(
+                    f"GEORGIEPORGIES: Extracted today's flavor using {extraction_path} path"
+                )
             if not flavor_name:
                 self.logger.warning(
                     "GEORGIEPORGIES: No flavor found; trying Playwright browser fetch"
                 )
                 html = self._try_playwright_browser_fetch(GEORGIE_PORGIES_FORECAST_URL) or html
-                flavor_name, description = self._extract_todays_flavor(html)
+                flavor_name, description, extraction_path = self._extract_todays_flavor(html)
+                if extraction_path:
+                    self.logger.info(
+                        f"GEORGIEPORGIES: Extracted today's flavor using {extraction_path} path"
+                    )
             if not flavor_name:
                 self.log_error("No flavor found for today")
                 return []
@@ -75,12 +84,13 @@ class GeorgiePorgiesScraper(BaseScraper):
 
     def _extract_todays_flavor(self, html):
         """Extract today's flavor name and description from forecast HTML."""
-        heading = html.find(
-            ["h1", "h2", "h3", "h4"],
-            string=lambda text: text and "today" in text.lower() and "flavor" in text.lower(),
-        )
+        flavor_name, description = self._extract_todays_flavor_from_data_date(html)
+        if flavor_name:
+            return flavor_name, description, "data-date"
+
+        heading = self._find_legacy_today_heading(html)
         if not heading:
-            return None, ""
+            return None, "", None
 
         image = heading.find_next("img")
         description = ""
@@ -97,7 +107,41 @@ class GeorgiePorgiesScraper(BaseScraper):
         if not flavor_name:
             flavor_name = self._extract_flavor_from_description(description)
 
+        if flavor_name:
+            return flavor_name, description, "legacy-heading"
+
+        return None, description, None
+
+    def _extract_todays_flavor_from_data_date(self, html):
+        """Extract today's flavor from forecast rows that include a YYYY-MM-DD data-date."""
+        today = get_central_date_string()
+        flavor_item = html.select_one(f'.flavor-item[data-date="{today}"]')
+        if not flavor_item:
+            return None, ""
+
+        name_tag = flavor_item.select_one(".flavor-list-name")
+        desc_tag = flavor_item.select_one(".flavor-list-desc")
+
+        flavor_name = name_tag.get_text(" ", strip=True) if name_tag else ""
+        description = desc_tag.get_text(" ", strip=True) if desc_tag else ""
+        flavor_name = flavor_name.strip(" -\u2014")
+
+        if not flavor_name:
+            return None, description
+        if "closed" in flavor_name.lower():
+            return "Closed", description
+
         return flavor_name, description
+
+    def _find_legacy_today_heading(self, html):
+        """Locate the legacy heading that introduces today's flavor section."""
+        for heading in html.find_all(["h1", "h2", "h3", "h4"]):
+            heading_text = heading.get_text(" ", strip=True).lower()
+            if "flavor of the day" in heading_text or (
+                "today" in heading_text and "flavor" in heading_text
+            ):
+                return heading
+        return None
 
     def _extract_flavor_from_image_alt(self, alt_text):
         """Extract flavor name from image alt text when available."""

--- a/app/scrapers/georgieporgies.py
+++ b/app/scrapers/georgieporgies.py
@@ -127,6 +127,8 @@ class GeorgiePorgiesScraper(BaseScraper):
         flavor_name = flavor_name.strip(" -\u2014")
 
         if not flavor_name:
+            if description and "closed" in description.lower():
+                return "Closed", description
             return None, description
         if "closed" in flavor_name.lower():
             return "Closed", description

--- a/tests/test_georgieporgies_scraper.py
+++ b/tests/test_georgieporgies_scraper.py
@@ -51,6 +51,28 @@ def _forecast_html(flavor_alt, description):
     """
 
 
+def _forecast_data_date_html(today_date, flavor_name, description):
+    return f"""
+    <html>
+      <body>
+        <h1>Georgie Porgie's <span>Flavor of the Day</span></h1>
+        <div class="flavor-forecast-section">
+          <h2>May FORECAST</h2>
+          <div class="flavor-master-list">
+            <div class="flavor-item" data-date="{today_date}">
+              <div class="flavor-list-line">
+                <span class="flavor-list-name">{flavor_name}</span>
+                <span class="flavor-list-sep">-</span>
+                <span class="flavor-list-desc">{description}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+    """
+
+
 class TestGeorgiePorgiesScraper(unittest.TestCase):
     def setUp(self):
         self.locations_patcher = patch("app.scrapers.scraper_base.get_locations_for_brand")
@@ -78,6 +100,46 @@ class TestGeorgiePorgiesScraper(unittest.TestCase):
             "Vanilla custard, banana slices, waffle pieces, Nutella swirls",
         )
 
+    @patch("app.scrapers.georgieporgies.get_central_date_string")
+    @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper.get_html")
+    def test_scrape_uses_data_date_primary_path(self, mock_get_html, mock_get_date):
+        mock_get_date.return_value = "2026-05-03"
+        mock_get_html.return_value = _make_soup(
+            _forecast_data_date_html(
+                "2026-05-03",
+                "Strawberry Shortcake",
+                "Vanilla custard, strawberries, yellow cake pieces",
+            )
+        )
+
+        results = GeorgiePorgiesScraper().scrape()
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(r["flavor"] == "Strawberry Shortcake" for r in results))
+        self.assertTrue(
+            all(
+                r["description"] == "Vanilla custard, strawberries, yellow cake pieces"
+                for r in results
+            )
+        )
+
+    @patch("app.scrapers.georgieporgies.get_central_date_string")
+    @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper.get_html")
+    def test_scrape_data_date_primary_handles_closed(self, mock_get_html, mock_get_date):
+        mock_get_date.return_value = "2026-05-04"
+        mock_get_html.return_value = _make_soup(
+            _forecast_data_date_html(
+                "2026-05-04",
+                "Closed",
+                "Closed for a day of prayers and rest",
+            )
+        )
+
+        results = GeorgiePorgiesScraper().scrape()
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(r["flavor"] == "Closed" for r in results))
+
     @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper.get_html")
     def test_scrape_returns_closed(self, mock_get_html):
         html = _forecast_html(
@@ -90,6 +152,22 @@ class TestGeorgiePorgiesScraper(unittest.TestCase):
 
         self.assertEqual(len(results), 2)
         self.assertTrue(all(r["flavor"] == "Closed" for r in results))
+
+    @patch("app.scrapers.georgieporgies.get_central_date_string")
+    @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper.get_html")
+    def test_scrape_falls_back_to_legacy_heading_path(self, mock_get_html, mock_get_date):
+        mock_get_date.return_value = "2026-05-03"
+        mock_get_html.return_value = _make_soup(
+            _forecast_html(
+                "Flavor of the Day - Mint Chocolate Chip",
+                "Refreshing mint with chocolate chips",
+            )
+        )
+
+        results = GeorgiePorgiesScraper().scrape()
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(r["flavor"] == "Mint Chocolate Chip" for r in results))
 
     @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper._try_playwright_browser_fetch")
     @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper.get_html")

--- a/tests/test_georgieporgies_scraper.py
+++ b/tests/test_georgieporgies_scraper.py
@@ -140,6 +140,26 @@ class TestGeorgiePorgiesScraper(unittest.TestCase):
         self.assertEqual(len(results), 2)
         self.assertTrue(all(r["flavor"] == "Closed" for r in results))
 
+    @patch("app.scrapers.georgieporgies.get_central_date_string")
+    @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper.get_html")
+    def test_scrape_data_date_closed_when_name_blank_and_desc_only(
+        self, mock_get_html, mock_get_date
+    ):
+        """Closed is returned when .flavor-list-name is blank and closure is only in .flavor-list-desc."""
+        mock_get_date.return_value = "2026-05-04"
+        mock_get_html.return_value = _make_soup(
+            _forecast_data_date_html(
+                "2026-05-04",
+                "",
+                "Closed for a Day of Prayer and Rest",
+            )
+        )
+
+        results = GeorgiePorgiesScraper().scrape()
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(r["flavor"] == "Closed" for r in results))
+
     @patch("app.scrapers.georgieporgies.GeorgiePorgiesScraper.get_html")
     def test_scrape_returns_closed(self, mock_get_html):
         html = _forecast_html(


### PR DESCRIPTION
## Problem
The ecosystem test was failing because the Georgie Porgies scraper returned 0 flavors. The site structure changed - the old extraction relied on image alt text that is now empty.

## Solution
Implemented a hybrid extraction approach:

### Primary Path (Data-Date)
- Extracts from structured forecast rows keyed by today's Central date (data-date="YYYY-MM-DD")
- Parses .flavor-list-name and .flavor-list-desc selectors
- Works with current site format

### Fallback Path (Legacy Heading)
- Preserves existing heading/image extraction logic
- Handles older page layouts gracefully
- Ensures backward compatibility if site reverts

### Enhancements
- Added path-level logging to track which extraction method succeeds
- Updated copilot-instructions.md with required venv activation rule
- Added comprehensive unit tests for both paths

## Testing
- ✅ 10 Georgie unit tests pass
- ✅ Direct runtime scrape returns today's flavor
- ✅ No flake8 linting issues
- ✅ All style checks pass

## Files Changed
- app/scrapers/georgieporgies.py: Hybrid extraction implementation
- tests/test_georgieporgies_scraper.py: Unit tests for both paths
- .github/copilot-instructions.md: Venv activation requirement